### PR TITLE
Search all APP2 sections for ICC profile data

### DIFF
--- a/src/PelJpeg.php
+++ b/src/PelJpeg.php
@@ -402,8 +402,14 @@ class PelJpeg
      */
     public function getICC()
     {
-        $icc = $this->getSection(PelJpegMarker::APP2);
-        return $icc;
+        $skip = 0;
+        while ($icc = $this->getSection(PelJpegMarker::APP2, $skip)) {
+            if (str_starts_with($icc->getBytes(), "ICC_PROFILE")) {
+                return $icc;
+            }
+            $skip ++;
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
See issue #20 .

Apple phones often include several images in one file using the Multi-Picture Format standard. This is implemented via a MPF0 object within an APP2 section. Pel should search for the ICC section instead of returning the first APP2 section.