### PR TITLE
PelEntryTime is not bijective

### DIFF
--- a/src/PelEntryTime.php
+++ b/src/PelEntryTime.php
@@ -151,7 +151,7 @@ class PelEntryTime extends PelEntryAscii
      *
      * @throws PelInvalidArgumentException
      */
-    public function setValue(int|float|string $timestamp, int $type = self::UNIX_TIMESTAMP): void
+    public function setValue(mixed $timestamp, int $type = self::UNIX_TIMESTAMP): void
     {
         if ($type === self::UNIX_TIMESTAMP) {
             if (is_string($timestamp)) {

--- a/src/PelEntryTime.php
+++ b/src/PelEntryTime.php
@@ -153,8 +153,6 @@ class PelEntryTime extends PelEntryAscii
      */
     public function setValue(mixed $timestamp, int $type = self::UNIX_TIMESTAMP): void
     {
-        assert(is_string($timestamp) || is_int($timestamp) || is_float($timestamp));
-
         if ($type === self::UNIX_TIMESTAMP) {
             if (is_string($timestamp)) {
                 if (is_numeric($timestamp)) {

--- a/src/PelEntryTime.php
+++ b/src/PelEntryTime.php
@@ -151,15 +151,18 @@ class PelEntryTime extends PelEntryAscii
      *
      * @throws PelInvalidArgumentException
      */
-    public function setValue(mixed $timestamp, int $type = self::UNIX_TIMESTAMP): void
+    public function setValue(int|float|string $timestamp, int $type = self::UNIX_TIMESTAMP): void
     {
         if ($type === self::UNIX_TIMESTAMP) {
-            if (is_int($timestamp) || is_float($timestamp)) {
-                $this->day_count = (int) $this->convertUnixToJd($timestamp);
-                $this->seconds = $timestamp % 86400;
-            } else {
-                throw new PelInvalidArgumentException('Expected integer value for $type, got %s', gettype($timestamp));
+            if (is_string($timestamp)) {
+                if (is_numeric($timestamp)) {
+                    $timestamp = (int) $timestamp;
+                } else {
+                    throw new PelInvalidArgumentException('Expected numeric value for $type, got "%s"', $timestamp);
+                }
             }
+            $this->day_count = (int) $this->convertUnixToJd($timestamp);
+            $this->seconds = $timestamp % 86400;
         } elseif ($type === self::EXIF_STRING) {
             /*
              * Clean the timestamp: some timestamps are broken other
@@ -179,12 +182,15 @@ class PelEntryTime extends PelEntryAscii
             $this->day_count = $this->convertGregorianToJd((int) $d[0], (int) $d[1], (int) $d[2]);
             $this->seconds = (int) $d[3] * 3600 + (int) $d[4] * 60 + (int) $d[5];
         } elseif ($type === self::JULIAN_DAY_COUNT) {
-            if (is_int($timestamp) || is_float($timestamp)) {
-                $this->day_count = (int) floor($timestamp);
-                $this->seconds = (int) (86400 * ($timestamp - floor($timestamp)));
-            } else {
-                throw new PelInvalidArgumentException('Expected integer value for $type, got %s', gettype($timestamp));
+            if (is_string($timestamp)) {
+                if (is_numeric($timestamp)) {
+                    $timestamp = (int) $timestamp;
+                } else {
+                    throw new PelInvalidArgumentException('Expected numeric value for $type, got "%s"', $timestamp);
+                }
             }
+            $this->day_count = (int) floor($timestamp);
+            $this->seconds = (int) (86400 * ($timestamp - floor($timestamp)));
         } else {
             throw new PelInvalidArgumentException('Expected UNIX_TIMESTAMP (%d), EXIF_STRING (%d), or JULIAN_DAY_COUNT (%d) for $type, got %d.', self::UNIX_TIMESTAMP, self::EXIF_STRING, self::JULIAN_DAY_COUNT, $type);
         }

--- a/src/PelEntryTime.php
+++ b/src/PelEntryTime.php
@@ -153,6 +153,8 @@ class PelEntryTime extends PelEntryAscii
      */
     public function setValue(mixed $timestamp, int $type = self::UNIX_TIMESTAMP): void
     {
+        assert(is_string($timestamp) || is_int($timestamp) || is_float($timestamp));
+
         if ($type === self::UNIX_TIMESTAMP) {
             if (is_string($timestamp)) {
                 if (is_numeric($timestamp)) {

--- a/test/ReadWriteTest.php
+++ b/test/ReadWriteTest.php
@@ -216,6 +216,7 @@ class ReadWriteTest extends TestCase
         unset($jpeg);
 
         $data_reload = exif_read_data($out_uri);
+        $this->assertIsArray($data_reload);
         $this->assertArrayHasKey('Make', $data_reload);
         $this->assertEquals('Foo-Bar', $data_reload['Make']);
 

--- a/test/ReadWriteTest.php
+++ b/test/ReadWriteTest.php
@@ -192,6 +192,31 @@ class ReadWriteTest extends TestCase
     }
 
     /**
+     * Tests loading and writing back a JPEG image file.
+     */
+    public function testJpegLoadSave(): void
+    {
+        $file_uri = __DIR__ . '/imagetests/canon-eos-650d.jpg';
+        $jpeg = new PelJpeg($file_uri);
+        $ifd0 = $jpeg->getExif()->getTiff()->getIfd();
+
+        $entry = $ifd0->getEntry(271); // Make
+        $this->assertInstanceOf(PelEntryAscii::class, $entry);
+        $this->assertSame('Canon', $entry->getValue());
+        $entry->setValue('Foo-Bar');
+
+        $out_uri = __DIR__ . '/imagetests/output.canon-eos-650d.jpg';
+        $jpeg->saveFile($out_uri);
+
+        unset($jpeg);
+
+        $data_reload = exif_read_data($out_uri);
+        $this->assertEquals('Foo-Bar', $data_reload['Make']);
+
+        unlink($out_uri);
+    }
+
+    /**
      * Tests loading and writing back a TIFF image file.
      */
     public function testTiffLoadSave(): void

--- a/test/ReadWriteTest.php
+++ b/test/ReadWriteTest.php
@@ -198,7 +198,12 @@ class ReadWriteTest extends TestCase
     {
         $file_uri = __DIR__ . '/imagetests/canon-eos-650d.jpg';
         $jpeg = new PelJpeg($file_uri);
-        $ifd0 = $jpeg->getExif()->getTiff()->getIfd();
+        $exif = $jpeg->getExif();
+        $this->assertInstanceOf(PelExif::class, $exif);
+        $tiff = $exif->getTiff();
+        $this->assertInstanceOf(PelTiff::class, $tiff);
+        $ifd0 = $tiff->getIfd();
+        $this->assertInstanceOf(PelIfd::class, $ifd0);
 
         $entry = $ifd0->getEntry(271); // Make
         $this->assertInstanceOf(PelEntryAscii::class, $entry);
@@ -211,6 +216,7 @@ class ReadWriteTest extends TestCase
         unset($jpeg);
 
         $data_reload = exif_read_data($out_uri);
+        $this->assertArrayHasKey('Make', $data_reload);
         $this->assertEquals('Foo-Bar', $data_reload['Make']);
 
         unlink($out_uri);


### PR DESCRIPTION
Since #31, strict typing made so that timestamps are saved as strings in the object structure, but when saving a file it is expected they are ints, so the save fails.